### PR TITLE
Mark Comminique as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,3 @@
-# Flathub
+# Comminique
 
-Flathub is the central place for building and hosting Flatpak builds.
-
-Using the Flathub repository
-----------------------------
-
-To install applications that are hosted on Flathub, use the following:
-```
-flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
-flatpak install flathub org.gnome.Recipes
-```
-
-To install applications from the beta branch, use the following:
-```
-flatpak remote-add flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-flatpak install flathub-beta org.godotengine.Godot
-```
-
-For more information and more applications see https://flathub.org
-
-Contributing to Flathub
------------------------
-
-For information on creating packages or reporting issues please see the [contributing page](/CONTRIBUTING.md).
-
-***Note:*** *this repository is not for reporting issues related to the flathub.org website itself or contributing to its development. For that, go to https://github.com/flathub/linux-store-frontend*
+___This application is no longer maintained.___

--- a/com.github.suzie97.communique.yml
+++ b/com.github.suzie97.communique.yml
@@ -108,7 +108,7 @@ modules:
   - name: gnome-online-accounts
     sources:
     - type: archive
-      url: https://download-fallback.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.0.tar.xz
+      url: https://download.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.0.tar.xz
       sha256: 585c4f979f6f543b77bfdb4fb01eb18ba25c2aec5b7866c676d929616fb2c3fa
 
   - name: gumbo
@@ -122,5 +122,9 @@ modules:
     sources:
       - type: archive
         url: https://github.com/Suzie97/Communique/archive/refs/tags/v1.2.0.tar.gz
-        sha256: 58cd1da08ca7ea65ab6386b8d6cdb0069b081a43cff3cb4af692a9917342fb6b
-        
+        sha256: b603ee2414d7773522145ec4cd22c539d0bfee0aacacb115e3b8aec760dca5c5
+    post-install:
+      # workaround for non-png-icon-in-hicolor-size-folder lint error
+      - mkdir -p /app/share/icons/hicolor/scalable/apps
+      - mv /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - find /app/share/icons/hicolor -type f -not -path "*scalable*" -not -path "*actions*" -name "*.svg" -delete

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
@bbhtt  This application uses a very old runtime that was marked as end-of-life (EOL) years ago.

The source code repository (https://github.com/Suzie97/Communique) seems to have been transferred from Suzie97 into a new account (https://github.com/ellie-commons).

Communique uses WebKitGTK-4.0, which has known security bugs.

I suggest marking this project as EOL.

```
LC_ALL=C flatpak remote-info flathub --system org.gnome.Platform//41
End-of-life: The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
Date: 2022-10-17 20:59:02 +0000
```
